### PR TITLE
Feature/check for twitter api keys

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -40,8 +40,7 @@ class MrNodeBot {
         // TwitterClient
         // Check to see if twitter is enabled in the config, but only if that key is available, 
         // since legacy versions didn't expect it.
-        if (typeof (this.Config.features.twitter.enabled) === 'undefined' ||
-            this.Config.features.twitter.enabled) {
+        if (_.isEmpty(this.Config.features.twitter.enabled) || !this.Config.features.twitter.enabled) {
             // Check to see if you have API keys configured to properly load the TwitterClient
             if (!this.Config.apiKeys.twitter.consumerKey ||
                 !this.Config.apiKeys.twitter.consumerSecret ||

--- a/bot.js
+++ b/bot.js
@@ -38,15 +38,20 @@ class MrNodeBot {
         this._pusher = this.Config.pusher.enabled ? new Pusher(this.Config.pusher.config) : false;
 
         // TwitterClient
-        // Check to see if you have API keys configured to properly load the TwitterClient
-        if (!this.Config.apiKeys.twitter.consumerKey ||
-            !this.Config.apiKeys.twitter.consumerSecret ||
-            !this.Config.apiKeys.twitter.tokenKey ||
-            !this.Config.apiKeys.twitter.tokenSecret) {
-            conLogger('Twitter API keys not configured in config.js: bypassing TwitterClient', 'danger');
-        } 
-        else {
-            this._twitterClient = require('./lib/twitterClient');
+        // Check to see if twitter is enabled in the config, but only if that key is available, 
+        // since legacy versions didn't expect it.
+        if (typeof (this.Config.features.twitter.enabled) === 'undefined' ||
+            this.Config.features.twitter.enabled) {
+            // Check to see if you have API keys configured to properly load the TwitterClient
+            if (!this.Config.apiKeys.twitter.consumerKey ||
+                !this.Config.apiKeys.twitter.consumerSecret ||
+                !this.Config.apiKeys.twitter.tokenKey ||
+                !this.Config.apiKeys.twitter.tokenSecret) {
+                conLogger('Twitter API keys not configured in config.js: bypassing TwitterClient', 'danger');
+            }
+            else {
+                this._twitterClient = require('./lib/twitterClient');
+            }
         }
 
         // A list of collections used

--- a/bot.js
+++ b/bot.js
@@ -43,7 +43,7 @@ class MrNodeBot {
             !this.Config.apiKeys.twitter.consumerSecret ||
             !this.Config.apiKeys.twitter.tokenKey ||
             !this.Config.apiKeys.twitter.tokenSecret) {
-            conLogger('Twitter API keys not configured in config.js: bypassing TwitterClient', 'error');
+            conLogger('Twitter API keys not configured in config.js: bypassing TwitterClient', 'danger');
         } 
         else {
             this._twitterClient = require('./lib/twitterClient');

--- a/bot.js
+++ b/bot.js
@@ -38,7 +38,16 @@ class MrNodeBot {
         this._pusher = this.Config.pusher.enabled ? new Pusher(this.Config.pusher.config) : false;
 
         // TwitterClient
-        this._twitterClient = require('./lib/twitterClient');
+        // Check to see if you have API keys configured to properly load the TwitterClient
+        if (!this.Config.apiKeys.twitter.consumerKey ||
+            !this.Config.apiKeys.twitter.consumerSecret ||
+            !this.Config.apiKeys.twitter.tokenKey ||
+            !this.Config.apiKeys.twitter.tokenSecret) {
+            conLogger('Twitter API keys not configured in config.js: bypassing TwitterClient', 'error');
+        } 
+        else {
+            this._twitterClient = require('./lib/twitterClient');
+        }
 
         // A list of collections used
         this.AdmCallbacks = new HashMap();

--- a/config.js.sample
+++ b/config.js.sample
@@ -111,7 +111,7 @@ module.exports = {
     apiKeys: {
         google: '',
         twitter: {
-            consumerKey: '',
+            consumerKey: '', // Fill these in from https://apps.twitter.com/
             consumerSecret: '',
             tokenKey: '',
             tokenSecret: ''
@@ -163,6 +163,7 @@ module.exports = {
             idleChat: 5 // Mins
         },
         twitter: {
+            enabled: true,
             followers: 'whoismrrobot, samesmail, mrrobotquotes',
             channels: ['#mrnodebot']
         },


### PR DESCRIPTION
I had to ask @davericher what the error was on bot load with twitterClient.stream().  The issue was Twitter API keys were omitted from the config.js file.  This short snippet will tell other that in the future, and bypass the loading of TwitterClient unless they are present.  