### PR TITLE
Bugfix: config.js features.twitter.enabled read error

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -40,7 +40,7 @@ class MrNodeBot {
         // TwitterClient
         // Check to see if twitter is enabled in the config, but only if that key is available, 
         // since legacy versions didn't expect it.
-        if (_.isEmpty(this.Config.features.twitter.enabled) || !this.Config.features.twitter.enabled) {
+        if (_.isUndefined(this.Config.features.twitter.enabled) || this.Config.features.twitter.enabled) {
             // Check to see if you have API keys configured to properly load the TwitterClient
             if (!this.Config.apiKeys.twitter.consumerKey ||
                 !this.Config.apiKeys.twitter.consumerSecret ||

--- a/scripts/listeners/twitter.js
+++ b/scripts/listeners/twitter.js
@@ -14,15 +14,19 @@ module.exports = app => {
     if (!app._twitterClient) {
         return;
     }
+    
+    let twitterEnabled = (_.isUndefined(app.Config.features.twitter.enabled) || app.Config.features.twitter.enabled);
 
     const say = (tweet) => {
         // Announce to Channels
         app.Config.features.twitter.channels.forEach((chan) => {
+            if (!twitterEnabled) return;
             app.say(chan, `[Twitter] @${tweet.user.screen_name}: ${tweet.text}`);
         });
     };
 
     const push = (tweet) => {
+        if (!twitterEnabled) return;
         // Load in pusher if it is active
         if (!app.Config.pusher.enabled && !app._pusher) {
             return;
@@ -47,6 +51,7 @@ module.exports = app => {
 
     // the Main twitter watcher
     const watcher = () => {
+        if (!twitterEnabled) return;
         let newStream = app._twitterClient.stream('user', {
             with: app.Config.features.twitter.followers
         });
@@ -63,6 +68,7 @@ module.exports = app => {
 
     // Tweet a message
     const tweetCmd = (to, from, text, message) => {
+        if (!twitterEnabled) return;
         if (!text) {
             app.say(from, 'Cannot tweet nothing champ...');
             return;
@@ -73,6 +79,7 @@ module.exports = app => {
         };
 
         app._twitterClient.post('statuses/update', twitConfig, (error, tweet, response) => {
+            if (!twitterEnabled) return;
             if (error) {
                 conLogger('Twitter Error: ' + error, 'error');
                 app.say(from, 'Something is not quite right with your tweet');


### PR DESCRIPTION
TLDR: Squashed a bug preventing the config.js `Config.features.twitter.enabled` setting from being read correctly.  

Description: The root of the issue was lodash `_.isEmpty(obj);` function, which returns `true` if the passed obj is an empty array, or if the passed obj is not an array-like object with enumerable properties.

Such as in the case of a boolean: `_.isEmpty(true);` and `_.isEmpty(false);` will both always return `true` in addition to `_.isEmpty(void 0);` (an undefined obj), which defeats the purpose of the condition.  [lodash.isEmpty() Documentation](https://github.com/lodash/lodash/blob/338f0f7b97c7d54937a0f9544a86286b0ff6db44/dist/lodash.js#L6808)

The result was loading the twitter module even if `Config.features.twitter.enabled` was `false`.

Changed to `_.isUndefined(obj);` [lodash.isUndefined() Documentation](https://github.com/lodash/lodash/blob/338f0f7b97c7d54937a0f9544a86286b0ff6db44/dist/lodash.js#L7163). 