### PR TITLE
Fixed voting notice

### DIFF
--- a/scripts/listeners/popularityActionListener.js
+++ b/scripts/listeners/popularityActionListener.js
@@ -107,7 +107,7 @@ module.exports = app => {
                     timeouts.set(from, tmpTimeout);
                 }, delayInMs);
 
-                app.notice(to, `You have just given ${result[1]} a ${result[2]} vote on ${to}`)
+                app.notice(from, `You have just given ${result[1]} a ${result[2]} vote on ${to}`)
             })
             .catch(err => logger.error(`Error in Popularity Listener`, {
                 err: err.stack || 'No Stack available'


### PR DESCRIPTION
Voting currently sends a voting notice to entire channel instead of just the voter, which has been the subject of much consternation among the bot's main channel. This patch makes the bot fall more in line with traditionally-accepted IRC bot ettiquette.